### PR TITLE
Pundit for coach views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,9 @@
 class ApplicationController < ActionController::Base
+  include Pundit
   before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
+
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
   def configure_permitted_parameters
     # For additional fields in app/views/devise/registrations/new.html.erb
@@ -8,5 +11,12 @@ class ApplicationController < ActionController::Base
 
     # For additional in app/views/devise/registrations/edit.html.erb
     devise_parameter_sanitizer.permit(:account_update, keys: [:name, :contact_number, :date_of_birth, :photo])
+  end
+
+  private
+
+  def user_not_authorized
+    flash[:alert] = "You are not authorized to perform this action."
+    redirect_to(root_path)
   end
 end

--- a/app/controllers/coach/lessons_controller.rb
+++ b/app/controllers/coach/lessons_controller.rb
@@ -3,7 +3,7 @@ module Coach
     before_action :set_lesson, only: [:show, :edit, :update, :destroy]
 
     def index
-      @lessons = Lesson.where(coach_id: current_user.id)
+        @lessons = policy_scope(Lesson)
     end
 
     def show
@@ -15,7 +15,6 @@ module Coach
 
     def create
       @lesson = Lesson.new(lesson_params)
-      # @user = current_user
       @lesson.coach = current_user
       @lesson.status = false
       if @lesson.save
@@ -46,6 +45,7 @@ module Coach
 
     def set_lesson
       @lesson = Lesson.find(params[:id])
+      authorize @lesson
     end
   end
 end

--- a/app/controllers/coach/lessons_controller.rb
+++ b/app/controllers/coach/lessons_controller.rb
@@ -3,7 +3,8 @@ module Coach
     before_action :set_lesson, only: [:show, :edit, :update, :destroy]
 
     def index
-        @lessons = policy_scope(Lesson)
+      @lessons = current_user.lessons_to_teach
+      policy_scope([:coach, @lessons])
     end
 
     def show
@@ -45,7 +46,7 @@ module Coach
 
     def set_lesson
       @lesson = Lesson.find(params[:id])
-      authorize @lesson
+      authorize([:coach, @lesson])
     end
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,53 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    scope.where(:id => record.id).exists?
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  def scope
+    Pundit.policy_scope!(user, record.class)
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope
+    end
+  end
+end

--- a/app/policies/coach/lesson_policy.rb
+++ b/app/policies/coach/lesson_policy.rb
@@ -1,0 +1,33 @@
+class Coach::LessonPolicy < ApplicationPolicy
+  def index
+    policy_scope(@lessons)
+  end
+
+  def show
+    post = authorize Lesson.find(params[:id])
+  end
+
+  def show
+    true
+  end
+
+  def new?
+    create?
+  end
+
+  def create?
+    true  # Anyone can create a lesson
+  end
+
+  def edit?
+    update?
+  end
+
+  def update?
+    record.coach == user # Only lesson coach can update it
+  end
+
+  def destroy?
+    record.coach == user # Only lesson coach can destroy it
+  end
+end

--- a/app/policies/lesson_policy.rb
+++ b/app/policies/lesson_policy.rb
@@ -1,10 +1,17 @@
 class LessonPolicy < ApplicationPolicy
   class Scope < Scope
+
+    def policy_scope(scope)
+      super([:coach, scope])
+    end
+
+    def authorize(record, query = nil)
+      super([:coach, record], query)
+    end
+
     def resolve
        if user.coach_profile
         scope.where(coach_id: user.id)
-      else
-        false  # Not too sure what to put here yet
       end
     end
 

--- a/app/policies/lesson_policy.rb
+++ b/app/policies/lesson_policy.rb
@@ -1,0 +1,36 @@
+class LessonPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+       if user.coach_profile
+        scope.where(coach_id: user.id)
+      else
+        false  # Not too sure what to put here yet
+      end
+    end
+
+    def show
+      true
+    end
+
+    def new?
+      create?
+    end
+
+    def create?
+      true  # Anyone can create a lesson
+    end
+
+    def edit?
+      update?
+    end
+
+    def update?
+      record.coach == user # Only lesson coach can update it
+    end
+
+    def destroy?
+      record.coach == user # Only lesson coach can destroy it
+    end
+
+  end
+end

--- a/test/policies/lesson_policy_test.rb
+++ b/test/policies/lesson_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class LessonPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
Hi guys, I'm trying to add authorization for coach views, but i need help... For a start, i'm trying to implement this:
1. A normal user shouldnt' be authorized to enter the coach namespace routes (e.g. coach/lessons)
2. A coach shouldn't be able to edit/delete other lessons that do not belong to them.

Resources:
Le Wagon's lecture code repo: https://github.com/lewagon/rails-pundit/compare/app-without-authorization...app-with-authorization?diff=split&name=app-with-authorization
Pundit's official doc: https://github.com/varvet/pundit

But I can't seem to get it right. The Index and create action looks ok, but the Edit and Delete action can't work (do not have authorization, will be routed back to home page). 

What i have tried so far:
1. Tried namespacing the Lesson Policy (put the file in a coach folder). The docs imply it's possible, but I tried it and it dosent work. Looked at some stackoverflow replies that also report the same problem. 
2. Checked the record and user (in the ApplicationPolicy's initialize by adding a 'raise') returns the correct record (the lesson I'm trying to edit) and the user (current_user). Tested the authentication condition (record.coach == user) in the console and it returns true. I'm quite lost what's wrong now.

If anyone can see what i'm missing, please let me know! Will continue to work on this...